### PR TITLE
fix: add typings to package.json export

### DIFF
--- a/packages/ndk-react/package.json
+++ b/packages/ndk-react/package.json
@@ -13,7 +13,8 @@
   "exports": {
     ".": {
       "import": "./dist/ndk-react.es.js",
-      "require": "./dist/ndk-react.umd.js"
+      "require": "./dist/ndk-react.umd.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "main": "./dist/ndk-react.umd.js",


### PR DESCRIPTION
When importing the package in a project made with [Vite](https://vitejs.dev/), I get the following error:
```
Could not find a declaration file for module '@nostr-dev-kit/ndk-react'. '/my-dir/node_modules/@nostr-dev-kit/ndk-react/dist/ndk-react.es.js' implicitly has an 'any' type.
  There are types at '/my-dir/node_modules/@nostr-dev-kit/ndk-react/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@nostr-dev-kit/ndk-react' library may need to update its package.json or typings.ts(7016)
```

This seems to be a known issue when using `moduleResolution: "bundler"` via Vite. You can see the related discussion in https://github.com/microsoft/TypeScript/issues/52363 as well as the same fix applied to other projects [[1](https://github.com/thomasbrodusch/vitest-fail-on-console/pull/11), [2](https://github.com/magiclabs/magic-js/pull/517)].

This PR adds the missing type specification in `exports` of `package.json`.

### Steps to reproduce

1. Create a new vite-react-app using `npx vite@latest` .
2. Install the `@nostr-dev-kit/ndk-react` package and import it somewhere it in the application.
3. Confirm that the types are not able to load.