### PR TITLE
changed version to current ndk

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -21,7 +21,7 @@
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.2",
     "typescript": "5.1.3",
-    "@nostr-dev-kit/ndk": "^0.8.1",
+    "@nostr-dev-kit/ndk": "^2.10.0",
     "@nostr-dev-kit/ndk-react": "0.1.1"
   },
   "devDependencies": {

--- a/packages/ndk-react/package.json
+++ b/packages/ndk-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nostr-dev-kit/ndk-react",
   "license": "Apache-2.0",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "tsc && vite build --watch",
@@ -33,7 +33,7 @@
     "@vitejs/plugin-react": "^2.1.0",
     "eslint": "^8.2.0",
     "eslint-utils": "^3.0.0",
-    "@nostr-dev-kit/ndk": "0.7.7",
+    "@nostr-dev-kit/ndk": "^2.10.0",
     "@types/ramda": "^0.29.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/ndk-react/src/context/index.tsx
+++ b/packages/ndk-react/src/context/index.tsx
@@ -53,6 +53,7 @@ interface NDKContext {
         }
       | undefined
   ) => Promise<undefined | NDKEvent>;
+  logout: () => Promise<void>;
   getUser: (_: string) => NDKUser;
   getProfile: (_: string) => NDKUserProfile;
 }
@@ -65,6 +66,7 @@ const NDKContext = createContext<NDKContext>({
   loginWithSecret: (_: string) => Promise.resolve(undefined),
   loginWithNip07: () => Promise.resolve(undefined),
   signPublishEvent: (_: NDKEvent, __?: {}) => Promise.resolve(undefined),
+  logout: () => Promise.resolve(undefined),
   getUser: (_: string) => {
     return NDKUser.prototype;
   },
@@ -110,6 +112,10 @@ const NDKProvider = ({
     }
   }
 
+  async function logout() {
+    await setSigner(undefined);
+  }
+
   return (
     <NDKContext.Provider
       value={{
@@ -120,6 +126,7 @@ const NDKProvider = ({
         loginWithNip46,
         loginWithSecret,
         signPublishEvent,
+        logout,
         getUser,
         getProfile,
       }}

--- a/packages/ndk-react/src/context/instance.ts
+++ b/packages/ndk-react/src/context/instance.ts
@@ -43,10 +43,24 @@ export default function NDKInstance(explicitRelayUrls: string[]) {
     }
   }
 
+  function unloadNdk() {
+    if (ndk === undefined) return;
+    _setSigner(undefined);
+    const connectedRelays = ndk.pool.connectedRelays();
+    connectedRelays.forEach((relay) => {
+      relay.disconnect();
+    });
+    _setNDK(undefined);
+  }
+
   async function setSigner(
-    signer: NDKPrivateKeySigner | NDKNip46Signer | NDKNip07Signer
+    signer: NDKPrivateKeySigner | NDKNip46Signer | NDKNip07Signer | undefined
   ) {
-    loadNdk(explicitRelayUrls, signer);
+    if( signer !== undefined ) {
+      await loadNdk(explicitRelayUrls, signer);
+    } else {
+      unloadNdk();
+    }
   }
 
   async function fetchEvents(filter: NDKFilter): Promise<NDKEvent[]> {

--- a/packages/starter/package.json
+++ b/packages/starter/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@nostr-dev-kit/ndk": "^0.8.1",
+    "@nostr-dev-kit/ndk": "^2.10.0",
     "@nostr-dev-kit/ndk-react": "0.1.1",
     "@types/node": "20.4.7",
     "@types/react": "18.2.18",


### PR DESCRIPTION
Changed the version of the ndk dependency to something over 2, so it doesn't break react apps using ndk 2.x.x with the outbox model included.
If you use NDK 2.x.x in your React app, sendPublishEvent will throw an error that connectedRelays is not defined in pool. That is because of the type mismatch between the dependency NDK version in ndk-react and the one used in the app using ndk-react.